### PR TITLE
fetch data from missions api

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3280,6 +3280,14 @@
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.4.1.tgz",
       "integrity": "sha512-gd1kmb21kwNuWr6BQz8fv6GNECPBnUasepcoLbekws23NVBLODdsClRZ+bQ8+9Uomf3Sm3+Vwn0oYG9NvwnJCw=="
     },
+    "axios": {
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.0.tgz",
+      "integrity": "sha512-lKoGLMYtHvFrPVt3r+RBMp9nh34N0M8zEfCWqdWZx6phynIEhQqAdydpyBAAG211zlhX9Rgu08cOamy6XjE5Og==",
+      "requires": {
+        "follow-redirects": "^1.14.8"
+      }
+    },
     "axobject-query": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@testing-library/jest-dom": "^5.16.2",
     "@testing-library/react": "^12.1.3",
     "@testing-library/user-event": "^13.5.0",
+    "axios": "^0.26.0",
     "node-sass": "^7.0.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/src/App.js
+++ b/src/App.js
@@ -1,17 +1,21 @@
 import { Routes, Route } from 'react-router-dom';
+import { Provider } from 'react-redux';
 import Header from './components/Header';
 import Rockets from './components/Rockets';
 import Missions from './components/Missions';
 import MyProfile from './components/MyProfile';
+import store from './redux/configureStore';
 
 const App = () => (
   <div className="App">
     <Header />
-    <Routes>
-      <Route path="/" element={<Rockets />} />
-      <Route path="/Missions" element={<Missions />} />
-      <Route path="/MyProfile" element={<MyProfile />} />
-    </Routes>
+    <Provider store={store}>
+      <Routes>
+        <Route path="/" element={<Rockets />} />
+        <Route path="/Missions" element={<Missions />} />
+        <Route path="/MyProfile" element={<MyProfile />} />
+      </Routes>
+    </Provider>
   </div>
 );
 

--- a/src/components/Missions.js
+++ b/src/components/Missions.js
@@ -1,9 +1,19 @@
-import React from 'react';
+import { render } from '@testing-library/react';
+import React, { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
+import { getFromApi } from '../redux/missions/missions';
 
-const Missions = () => (
-  <div>
-    <h1>Missions Page</h1>
-  </div>
-);
+const Missions = () => {
+  const dispatch = useDispatch();
+  useEffect(() => {
+    dispatch(getFromApi());
+  }, [dispatch]);
+
+  render(
+    <div className="clm-row">
+      Mission fetched
+    </div>,
+  );
+};
 
 export default Missions;

--- a/src/redux/configureStore.js
+++ b/src/redux/configureStore.js
@@ -1,0 +1,15 @@
+import { createStore, combineReducers, applyMiddleware } from 'redux';
+import logger from 'redux-logger';
+import thunk from 'redux-thunk';
+import missionsReducer from './missions/missions';
+
+const reducer = combineReducers({
+  missionsReducer,
+});
+
+const store = createStore(
+  reducer,
+  applyMiddleware(logger, thunk),
+);
+
+export default store;

--- a/src/redux/missions/missions.js
+++ b/src/redux/missions/missions.js
@@ -1,0 +1,55 @@
+import axios from 'axios';
+
+const GET_DATA = 'GET_DATA';
+const CHANGE_STATE = 'CHANGE_STATE';
+
+const url = 'https://api.spacexdata.com/v3/missions';
+const initialState = [];
+const fecthValue = (result, newArr) => {
+  Object.keys(result).forEach((itemId) => {
+    newArr.push({
+      mission_id: itemId,
+      mission_name: result[itemId][0].name,
+      description: result[itemId][0].description,
+      joinMission: false,
+    });
+  });
+};
+
+const getBook = (payload) => ({
+  type: GET_DATA,
+  payload,
+});
+
+export const changeMission = (id) => ({
+  type: CHANGE_STATE,
+  payload: id,
+});
+
+// ---------------REDUCER------------------
+
+const missionsReducer = (state = initialState, action) => {
+  switch (action.type) {
+    case GET_DATA:
+      return action.payload;
+    case CHANGE_STATE:
+      return [...state.map((mission) => {
+        if (mission.mission_id === action.payload) {
+          return { mission, joined: !mission.joined };
+        }
+        return mission;
+      })];
+    default:
+      return state;
+  }
+};
+
+export const getFromApi = () => (dispatch) => axios
+  .get(url)
+  .then((res) => {
+    const newArr = [];
+    fecthValue(res.data, newArr);
+    dispatch(getBook(newArr));
+  });
+
+export default missionsReducer;


### PR DESCRIPTION
**In this PR I added functionalities for fetching data from the missions API.**
- [ ] I used (https://api.spacexdata.com/v3/missions) as endPoint when a user navigates to the Missions section.

- [ ] Once the data are fetched, dispatch an action to store the selected data in Redux store:
    1.   mission_id
    2.   mission_name
    3.   description

NOTE: I only dispatch those actions once and don't add data to store on every re-render (i.e. when changing views / using navigation).